### PR TITLE
reset searchInput and close drawer after adding icon or employee image

### DIFF
--- a/src/taskpane/employeeImageUtils.ts
+++ b/src/taskpane/employeeImageUtils.ts
@@ -1,5 +1,6 @@
 import { EmployeeName, ShapeType } from "./types";
 import { fetchEmployeeImage, fetchEmployeeNames } from "./employeeApiService";
+import {resetSearchInputAndDrawer} from "./taskpane";
 
 export let allCurrentNames: EmployeeName[] = [];
 
@@ -35,6 +36,7 @@ async function insertEmployeeImage(e: MouseEvent, name: string) {
   });
 
   button["loading"] = false;
+  resetSearchInputAndDrawer();
 }
 
 export async function getAllEmployeeNames() {

--- a/src/taskpane/iconDownloadUtils.ts
+++ b/src/taskpane/iconDownloadUtils.ts
@@ -1,5 +1,5 @@
 import { FetchIconResponse } from "./types";
-import { showErrorPopup } from "./taskpane";
+import {resetSearchInputAndDrawer, showErrorPopup} from "./taskpane";
 import { getRequestHeadersWithAuthorization } from "../security/authService";
 
 const proxyBaseUrl = `https://powerpoint-addin-ktor-pq9vk.ondigitalocean.app`;
@@ -53,6 +53,7 @@ async function insertSvgIcon(e: MouseEvent, icon: FetchIconResponse) {
   }
 
   button["loading"] = false;
+  resetSearchInputAndDrawer();
 }
 
 export async function fetchIcons(searchTerm: string): Promise<Array<FetchIconResponse>> {

--- a/src/taskpane/taskpane.ts
+++ b/src/taskpane/taskpane.ts
@@ -242,3 +242,10 @@ export function showErrorPopup(errorMessage: string) {
   popup.querySelector("span").innerHTML = errorMessage;
   popup.toast();
 }
+
+export function resetSearchInputAndDrawer() {
+  const drawer = document.getElementById("search-drawer") as HTMLElement;
+  drawer["open"] = false;
+  (document.getElementById("search-input") as HTMLInputElement).value = "";
+  (document.getElementById("active-drawer") as HTMLInputElement).value = "";
+}


### PR DESCRIPTION
https://www.notion.so/l21s/Icon-Suche-direkt-wieder-schlie-en-sobald-ein-Icon-eingef-gt-wurde-21437d27bd2680faa295c3e6aa5c213f?source=copy_link

- für Employee image Suche erweitert 