### PR TITLE
Fix/remove debounce at search and fix search result title

### DIFF
--- a/src/app/actions/employeesPreview.ts
+++ b/src/app/actions/employeesPreview.ts
@@ -6,7 +6,11 @@ import {ShapeType} from "../shared/consts";
 
 let employees: Employee[] = [];
 
-export async function getAllEmployeeNames() {
+export async function fetchAllEmployeeNames() {
+  if(employees.length) {
+    return;
+  }
+
   const employeeNames = await fetchEmployeeNames();
 
   employees = employeeNames.map((employee) => ({
@@ -17,16 +21,15 @@ export async function getAllEmployeeNames() {
         " " +
         employee.split("-")[0].charAt(0).toUpperCase() +
         employee.split("-")[0].slice(1),
-  }));
+  })).sort((a, b) => a.name.localeCompare(b.name));
 }
 
-export async function fetchEmployeesAddToPreview(searchTerm: string){
+export function filterEmployeesAndAddToPreview(searchTerm: string){
   let result = searchTerm ? filterEmployeeNames(searchTerm) : employees;
-  result.sort((a, b) => a.name.localeCompare(b.name));
-  addToEmployeesPreview(result);
+  addToPreview(result);
 }
 
-function addToEmployeesPreview(names: Employee[]) {
+function addToPreview(names: Employee[]) {
   document.querySelectorAll("sl-skeleton").forEach((skeletonItem) => skeletonItem.remove());
 
   names.forEach((name) => {

--- a/src/app/actions/iconsPreview.ts
+++ b/src/app/actions/iconsPreview.ts
@@ -6,12 +6,11 @@ import {downloadIconWith, fetchIcons, getDownloadPathForIconWith} from "../servi
 
 export let recentIcons: FetchIconResponse[] = [];
 
-export async function fetchIconsAndAddToPreview(searchTerm: string) {
-  let result = searchTerm ? await fetchIcons(searchTerm) : recentIcons;
-  addToIconPreview(result);
+export async function fetchIconsForPreview(searchTerm: string): Promise<FetchIconResponse[]> {
+  return searchTerm ? await fetchIcons(searchTerm) : recentIcons;
 }
 
-function addToIconPreview(icons: FetchIconResponse[]) {
+export function addToPreview(icons: FetchIconResponse[]) {
   document.querySelectorAll("sl-skeleton").forEach((skeleton) => skeleton.remove());
 
   icons.forEach((icon) => {

--- a/src/app/actions/iconsPreview.ts
+++ b/src/app/actions/iconsPreview.ts
@@ -6,8 +6,11 @@ import {downloadIconWith, fetchIcons, getDownloadPathForIconWith} from "../servi
 
 export let recentIcons: FetchIconResponse[] = [];
 
-export async function fetchIconsForPreview(searchTerm: string): Promise<FetchIconResponse[]> {
-  return searchTerm ? await fetchIcons(searchTerm) : recentIcons;
+export async function fetchIconsForPreview(
+    searchTerm: string,
+    abortSignal: AbortSignal
+): Promise<FetchIconResponse[]> {
+  return searchTerm ? await fetchIcons(searchTerm, abortSignal) : recentIcons;
 }
 
 export function addToPreview(icons: FetchIconResponse[]) {

--- a/src/app/actions/iconsPreview.ts
+++ b/src/app/actions/iconsPreview.ts
@@ -4,14 +4,14 @@ import {iconsPreview} from "../taskpane";
 import {FetchIconResponse} from "../shared/types";
 import {downloadIconWith, fetchIcons, getDownloadPathForIconWith} from "../services/iconApiService";
 
-const RECENT_ICONS_KEY = "recentIcons";
+const RECENT_ICONS_STORAGE_KEY = "recentIcons";
 const MAX_NUMBER_OF_RECENT_ICONS = 30;
 
 export async function fetchIconsForPreview(
     searchTerm: string,
     abortSignal: AbortSignal
 ): Promise<FetchIconResponse[]> {
-  return searchTerm ? await fetchIcons(searchTerm, abortSignal) : getRecentIcons();
+  return searchTerm ? await fetchIcons(searchTerm, abortSignal) : loadRecentIconsFromLocalStorage();
 }
 
 export function addToPreview(icons: FetchIconResponse[]) {
@@ -59,21 +59,21 @@ async function insertSvgIcon(e: MouseEvent, icon: FetchIconResponse) {
   resetSearchInputAndDrawer();
 }
 
-function getRecentIcons(): FetchIconResponse[] {
-  const json = localStorage.getItem(RECENT_ICONS_KEY);
-  return json ? (JSON.parse(json) as FetchIconResponse[]) : [];
+function loadRecentIconsFromLocalStorage(): FetchIconResponse[] {
+  const json = localStorage.getItem(RECENT_ICONS_STORAGE_KEY);
+  return json ? JSON.parse(json) : [];
 }
 
-function setRecentIcons(icons: FetchIconResponse[]): void {
-  localStorage.setItem(RECENT_ICONS_KEY, JSON.stringify(icons));
+function saveRecentIconsToLocalStorage(icons: FetchIconResponse[]): void {
+  localStorage.setItem(RECENT_ICONS_STORAGE_KEY, JSON.stringify(icons));
 }
 
 function addIconToRecentIcons(icon: FetchIconResponse): void {
-  const recent = getRecentIcons();
+  const recent = loadRecentIconsFromLocalStorage();
   const alreadyExists = recent.some((i) => i.id === icon.id);
 
   if (!alreadyExists) {
     const updated = [icon, ...recent].slice(0, MAX_NUMBER_OF_RECENT_ICONS);
-    setRecentIcons(updated);
+    saveRecentIconsToLocalStorage(updated);
   }
 }

--- a/src/app/actions/searchDrawer.ts
+++ b/src/app/actions/searchDrawer.ts
@@ -3,7 +3,6 @@ import {fetchEmployeesAddToPreview, getAllEmployeeNames} from "./employeesPrevie
 import {activeDrawer, drawer, searchInput, wrapper} from "../taskpane";
 
 let lastSearchQuery = "";
-const debouncedProcessInputChanges = debounce(processInputChanges);
 
 export async function handleDrawerChange(e: Event) {
   const activeDrawerTab = e.target as HTMLInputElement;
@@ -36,12 +35,12 @@ export async function handleDrawerChange(e: Event) {
     }
   }
 
-  debouncedProcessInputChanges(activeDrawerTab.value);
+  await processInputChanges(activeDrawerTab.value);
 }
 
-export function handleSearchInput() {
+export async function handleSearchInput() {
   refreshSearchResults(activeDrawer.value);
-  debouncedProcessInputChanges(activeDrawer.value);
+  await processInputChanges(activeDrawer.value);
 }
 
 export function closeDrawer() {
@@ -58,6 +57,7 @@ export function resetSearchInputAndDrawer() {
 function refreshSearchResults(activeDrawerTab: string) {
   if (activeDrawerTab) {
     document.getElementById(activeDrawerTab).replaceChildren();
+
     (document.querySelector("#search-input > sl-spinner:first-of-type") as HTMLElement).style.display = "block";
 
     for (let i = 0; i < 12; i++) {
@@ -76,7 +76,7 @@ async function processInputChanges(activeDrawerTab: string) {
     switch (activeDrawerTab) {
       case "icons": {
         await fetchIconsAndAddToPreview(searchInput.value);
-        searchResultTitle.innerText = searchInput ? 'Search results for "' + searchInput.value + '"' : "Recently used icons";
+        searchResultTitle.innerText = searchInput.value ? 'Search results for "' + searchInput.value + '"' : "Recently used icons";
         if (document.getElementById(activeDrawerTab).children.length === 0) {
           showMessageInDrawer("No recent icons yet");
         }
@@ -84,7 +84,7 @@ async function processInputChanges(activeDrawerTab: string) {
       }
       case "names": {
         await fetchEmployeesAddToPreview(searchInput.value);
-        searchResultTitle.innerText = searchInput ? 'Search results for "' + searchInput.value + '"' : "All employees";
+        searchResultTitle.innerText = searchInput.value ? 'Search results for "' + searchInput.value + '"' : "All employees";
         if (document.getElementById(activeDrawerTab).children.length === 0) {
           showMessageInDrawer("No names fitting this search query");
         }
@@ -95,17 +95,6 @@ async function processInputChanges(activeDrawerTab: string) {
     showMessageInDrawer("Could not fetch any " + activeDrawerTab + ": " + e.message);
   }
   (document.querySelector("#search-input > sl-spinner:first-of-type") as HTMLElement).style.display = "none";
-}
-
-
-function debounce(func: Function) {
-  let timer: NodeJS.Timeout;
-  return (...args: any[]) => {
-    clearTimeout(timer);
-    timer = setTimeout(() => {
-      func.apply(this, args);
-    }, 500);
-  };
 }
 
 function showMessageInDrawer(message: string) {

--- a/src/app/listener/searchDrawer.ts
+++ b/src/app/listener/searchDrawer.ts
@@ -26,7 +26,7 @@ function initializeDrawer() {
 }
 
 function initializeSearchInput() {
-    searchInput.addEventListener("sl-input", () => {
-        handleSearchInput()
+    searchInput.addEventListener("sl-input", async () => {
+        await handleSearchInput()
     });
 }

--- a/src/app/services/iconApiService.ts
+++ b/src/app/services/iconApiService.ts
@@ -32,16 +32,21 @@ export async function getDownloadPathForIconWith(id: string) {
   }
 }
 
-export async function fetchIcons(searchTerm: string): Promise<Array<FetchIconResponse>> {
-  const url = `${proxyBaseUrlIcons}?term=${searchTerm}`;
+export async function fetchIcons(
+    searchTerm: string,
+    abortSignal: AbortSignal
+): Promise<FetchIconResponse[]> {
+  const url = `${proxyBaseUrlIcons}?term=${encodeURIComponent(searchTerm)}`;
   const requestOptions = {
     method: "GET",
     headers: await getRequestHeadersWithAuthorization(),
+    signal: abortSignal,
   };
 
   try {
     const result = await fetch(url, requestOptions);
     const response = await result.json();
+
     return response.data
         .filter((obj: any) => obj.author.name === "Smashicons" && obj.family.name === "Basic Miscellany Lineal")
         .map((obj: any) => ({
@@ -50,6 +55,9 @@ export async function fetchIcons(searchTerm: string): Promise<Array<FetchIconRes
         }))
         .slice(0, 50);
   } catch (e) {
-    throw new Error("Error fetching icons: " + e);
+    if (e.name === "AbortError") {
+      throw e;
+    }
+    throw new Error("Error fetching icons: " + e.message);
   }
 }

--- a/src/app/taskpane.css
+++ b/src/app/taskpane.css
@@ -534,3 +534,4 @@ sl-alert::part(base) {
   flex: 1;
   min-width: 0;
 }
+


### PR DESCRIPTION
https://www.notion.so/l21s/FIX-Icon-und-Employee-Suche-debounce-Logik-entfernen-und-All-employees-Text-wieder-anzeigen-22c37d27bd2680c89e9cf46985152cfc?source=copy_link

Die Debounce-Logik war ursprünglich für die Icon-Suche gedacht, führte jedoch zu Problemen: 
Bei schnellen Änderungen im Suchfeld konnten veraltete Anfragen die Ergebnisse neuerer Suchanfragen überschreiben. Dieses Verhalten wurde nun durch den Einsatz des [AbortController]([url](https://developer.mozilla.org/en-US/docs/Web/API/AbortController/signal)) behoben. Jede neue Anfrage bricht automatisch die vorherige ab, wodurch sichergestellt ist, dass nur die Resultate der aktuellsten Suche verarbeitet und angezeigt werden. Auf diese Weise werden veraltete Ergebnisse zuverlässig ignoriert.

Zusammenhängend wird hier auch direkt das unnötige Laden bei der Employee-Suche behoben. Da wurde bisher dieselbe Debounce-Logik verwendet, obwohl da gar nix asynchron geladen wurde. Hat aber trotzdem bei jedem Input die Ladeanimation gezeigt, was dann einf so aussah als würde ständig was ans Backend gehen...

